### PR TITLE
Better Metadata support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "package.json",
     "route-manager.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thequinndev/docolate.git"
+  },
   "author": "thequinndev",
   "license": "MIT",
   "dependencies": {

--- a/src/route-manager/openapi/index.ts
+++ b/src/route-manager/openapi/index.ts
@@ -1,3 +1,4 @@
 export * from './compiler'
 export * from './manager'
 export * from './openapi.types'
+export * from './meta-manager'

--- a/src/route-manager/openapi/manager/index.ts
+++ b/src/route-manager/openapi/manager/index.ts
@@ -1,11 +1,13 @@
 import { apiBuilder } from "../../build-endpoint";
 import { EndpointArrayByOperationIds, EndpointBase, InferRequestAccepts } from "../../endpoint";
-import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta } from '../openapi.types'
+import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta, MetaConfigBase } from '../openapi.types'
 
 export const OpenAPIManager = <
-    SpecVersion extends OASVersions
+    SpecVersion extends OASVersions,
+    MetaConfig extends MetaConfigBase<SpecVersion>,
 >(config: {
     version: SpecVersion,
+    metaManager?: MetaConfig,
     defaultMetadata?: {
         responses?: GetResponseSpecMetaDefault<SpecVersion>
     }
@@ -19,7 +21,7 @@ export const OpenAPIManager = <
         paths?: InferPathsFromGroupForAnnotation<SpecVersion, Operations>,
         operations?: {
             [OperationId in keyof Operations]?: {
-                operation?: GetOperationSpecMeta<SpecVersion>,
+                operation?: GetOperationSpecMeta<SpecVersion, MetaConfig extends MetaConfigBase<SpecVersion> ? MetaConfig['customOperationMeta'] : []>,
                 requestBody?: GetRequestBodySpecMeta<SpecVersion, InferRequestAccepts<Operations[OperationId]['accepts'], 'body'>>,
                 responses?: InferResponsesForExamples<SpecVersion, Operations[OperationId]>
             }

--- a/src/route-manager/openapi/manager/index.ts
+++ b/src/route-manager/openapi/manager/index.ts
@@ -1,6 +1,6 @@
 import { apiBuilder } from "../../build-endpoint";
 import { EndpointArrayByOperationIds, EndpointBase, InferRequestAccepts } from "../../endpoint";
-import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta, MetaConfigBase } from '../openapi.types'
+import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta, MetaConfigBase, SafeTags } from '../openapi.types'
 
 export const OpenAPIManager = <
     SpecVersion extends OASVersions,
@@ -21,7 +21,11 @@ export const OpenAPIManager = <
         paths?: InferPathsFromGroupForAnnotation<SpecVersion, Operations>,
         operations?: {
             [OperationId in keyof Operations]?: {
-                operation?: GetOperationSpecMeta<SpecVersion, MetaConfig extends MetaConfigBase<SpecVersion> ? MetaConfig['customOperationMeta'] : []>,
+                operation?: GetOperationSpecMeta<
+                    SpecVersion,
+                    MetaConfig extends MetaConfigBase<SpecVersion> ? MetaConfig['customOperationMeta'] : never,
+                    MetaConfig extends MetaConfigBase<SpecVersion> ? SafeTags<SpecVersion, MetaConfig['tags']> : never
+                >,
                 requestBody?: GetRequestBodySpecMeta<SpecVersion, InferRequestAccepts<Operations[OperationId]['accepts'], 'body'>>,
                 responses?: InferResponsesForExamples<SpecVersion, Operations[OperationId]>
             }

--- a/src/route-manager/openapi/meta-manager/index.test.ts
+++ b/src/route-manager/openapi/meta-manager/index.test.ts
@@ -3,6 +3,30 @@ import { apiDocumentationEndpoints } from "../../../../examples/route-manager/en
 import { OpenAPIManager } from '../manager'
 
 describe("OpenAPIMetaManager", () => {
+
+    it("Will have no impact on OpenAPIManager if not provided", () => {
+
+        const apiManager = OpenAPIManager({
+            version: '3.0',
+        })
+        apiManager.addEndpointGroup(apiDocumentationEndpoints, {
+            'operations': {
+                'getApiDocumentation': {
+                    // The main test here is just that we don't get compiler errors when the extra keys are included
+                    'operation': {
+                        'description': 'Test',         
+                        'summary': 'Test',
+                    }
+                }
+            }
+        })
+
+        const operation = apiManager.build({failOnError: false}).spec.paths['/'].get
+
+        expect(operation['description']).toEqual('Test')
+        expect(operation['summary']).toEqual('Test')
+    })
+
     it("Will make operations extensible in the OpenAPIManager", () => {
         const metaManager = OpenAPIMetaManager({
             version: '3.0',
@@ -10,7 +34,6 @@ describe("OpenAPIMetaManager", () => {
                 'my-extra-key',
                 'any-key'
             ]
-            
         })
 
         const apiManager = OpenAPIManager({
@@ -25,7 +48,7 @@ describe("OpenAPIMetaManager", () => {
                         'description': 'Test',
                         // These should have no compiler errors
                         'my-extra-key': 'MyKey1',
-                        'any-key': 'MyKey2',
+                        'any-key': 'MyKey2'
                     }
                 }
             }
@@ -35,5 +58,40 @@ describe("OpenAPIMetaManager", () => {
 
         expect(operation['my-extra-key']).toEqual('MyKey1')
         expect(operation['any-key']).toEqual('MyKey2')
+    })
+
+    it("Will make tags extensible in the OpenAPIManager", () => {
+        const metaManager = OpenAPIMetaManager({
+            version: '3.0',
+            tags: [
+                {
+                    name: 'MyTag',
+                    description: 'My Tag'
+                },
+                {
+                    name: 'MyOtherTag',
+                }
+            ]
+        })
+
+        const apiManager = OpenAPIManager({
+            version: '3.0',
+            metaManager: metaManager
+        })
+        apiManager.addEndpointGroup(apiDocumentationEndpoints, {
+            'operations': {
+                'getApiDocumentation': {
+                    // The main test here is just that we don't get compiler errors when the extra keys are included
+                    'operation': {
+                        'description': 'Test',
+                        'tags': ['MyTag', 'MyOtherTag'],
+                    }
+                }
+            }
+        })
+
+        const operation = apiManager.build({failOnError: false}).spec.paths['/'].get
+
+        expect(operation['tags']).toEqual(['MyTag', 'MyOtherTag'])
     })
 });

--- a/src/route-manager/openapi/meta-manager/index.test.ts
+++ b/src/route-manager/openapi/meta-manager/index.test.ts
@@ -1,0 +1,39 @@
+import { OpenAPIMetaManager } from ".";
+import { apiDocumentationEndpoints } from "../../../../examples/route-manager/endpoints"
+import { OpenAPIManager } from '../manager'
+
+describe("OpenAPIMetaManager", () => {
+    it("Will make operations extensible in the OpenAPIManager", () => {
+        const metaManager = OpenAPIMetaManager({
+            version: '3.0',
+            customOperationMeta: [
+                'my-extra-key',
+                'any-key'
+            ]
+            
+        })
+
+        const apiManager = OpenAPIManager({
+            version: '3.0',
+            metaManager: metaManager
+        })
+        apiManager.addEndpointGroup(apiDocumentationEndpoints, {
+            'operations': {
+                'getApiDocumentation': {
+                    // The main test here is just that we don't get compiler errors when the extra keys are included
+                    'operation': {
+                        'description': 'Test',
+                        // These should have no compiler errors
+                        'my-extra-key': 'MyKey1',
+                        'any-key': 'MyKey2',
+                    }
+                }
+            }
+        })
+
+        const operation = apiManager.build({failOnError: false}).spec.paths['/'].get
+
+        expect(operation['my-extra-key']).toEqual('MyKey1')
+        expect(operation['any-key']).toEqual('MyKey2')
+    })
+});

--- a/src/route-manager/openapi/meta-manager/index.ts
+++ b/src/route-manager/openapi/meta-manager/index.ts
@@ -1,0 +1,10 @@
+import { MetaManagerConfig, OASVersions, TagItem } from "../openapi.types"
+
+export const OpenAPIMetaManager = <
+    SpecVersion extends OASVersions,
+    Tag extends TagItem<SpecVersion>,
+    ExtraOperationMeta extends string,
+>(config: MetaManagerConfig<
+    SpecVersion, Tag[], ExtraOperationMeta[]>) => {
+    return config
+}

--- a/src/route-manager/openapi/meta-manager/index.ts
+++ b/src/route-manager/openapi/meta-manager/index.ts
@@ -2,7 +2,8 @@ import { MetaManagerConfig, OASVersions, TagItem } from "../openapi.types"
 
 export const OpenAPIMetaManager = <
     SpecVersion extends OASVersions,
-    Tag extends TagItem<SpecVersion>,
+    TagName extends string,
+    Tag extends TagItem<SpecVersion,TagName>,
     ExtraOperationMeta extends string,
 >(config: MetaManagerConfig<
     SpecVersion, Tag[], ExtraOperationMeta[]>) => {

--- a/src/route-manager/openapi/openapi.types.ts
+++ b/src/route-manager/openapi/openapi.types.ts
@@ -40,29 +40,49 @@ export type InferPathsFromGroupForAnnotation<Version extends OASVersions, Group 
     [OperationId in keyof Group as Group[OperationId]['path']]?: GetPathSpecMeta<Version>
 }
 
+export type TagItem<Version extends OASVersions, TagName extends string> =
+(Omit<(Version extends '3.0' ? oas30.TagObject : oas31.TagObject), 'name'>) & {
+    name: TagName,
+    description?: string,
+    externalDocs?: oas31.TagObject['externalDocs']
+}
 
 export type MetaManagerConfig<
     SpecVersion extends OASVersions,
-    Tags extends TagItem<SpecVersion>[],
+    Tags extends TagItem<SpecVersion, string>[],
     ExtraOperationMeta extends string[]
 > = {
     version: SpecVersion,
     tags?: Tags,
     // Meta that doesn't exist natively in OpenAPI
     customOperationMeta?: ExtraOperationMeta,
-    
 }
 
 type InferCustomMetaOperations<OperationMetaConfig extends MetaConfigBase<OASVersions>['customOperationMeta']> = OperationMetaConfig extends string[] ? {
     [Item in OperationMetaConfig[number]]?: any
-} : {} 
+} : never
 
+export type InferTags<Tags> = Tags extends Record<string, true> ? {
+    tags?: (keyof Tags)[]
+} : {
+    tags?: string[]
+}
 
-export type MetaConfigBase<SpecVersion extends OASVersions> = MetaManagerConfig<SpecVersion, TagItem<SpecVersion>[], string[]>
+export type MetaConfigBase<SpecVersion extends OASVersions> = MetaManagerConfig<SpecVersion, TagItem<SpecVersion, string>[], string[]>
 
-export type GetOperationSpecMeta<Version extends OASVersions, MetaConfig extends MetaConfigBase<Version>['customOperationMeta']> = Pick<Version extends '3.0' ? oas30.OperationObject : oas31.OperationObject,
+export type GetOperationSpecMeta<
+    Version extends OASVersions,
+    MetaConfig extends MetaConfigBase<Version>['customOperationMeta'],
+    Tags extends Record<string, true>
+> = Pick<Version extends '3.0' ? oas30.OperationObject : oas31.OperationObject,
 'description' | 'summary' | 'deprecated' | 'security' | 'servers' | 'callbacks' | 'externalDocs'
 > & InferCustomMetaOperations<MetaConfig>
+& InferTags<Tags>
 
-export type TagItem<Version extends OASVersions> = Version extends '3.0' ? oas30.TagObject : oas31.TagObject
-
+export type SafeTags<SpecVersion extends OASVersions, Tags extends (TagItem<SpecVersion, string>[] | undefined)> =
+Tags extends {
+    name: string
+}[]
+? {
+    [Tag in Tags[number] as Tag['name']]: true
+} : never

--- a/src/route-manager/openapi/openapi.types.ts
+++ b/src/route-manager/openapi/openapi.types.ts
@@ -40,13 +40,6 @@ export type InferPathsFromGroupForAnnotation<Version extends OASVersions, Group 
     [OperationId in keyof Group as Group[OperationId]['path']]?: GetPathSpecMeta<Version>
 }
 
-type OperationExtraMeta<OperationMeta extends string[]> = {
-    operation: OperationMeta
-}
-
-type InferExtraMeta<OperationMeta extends string[]> = {
-    [K in keyof OperationMeta[number]]: any
-}
 
 export type MetaManagerConfig<
     SpecVersion extends OASVersions,

--- a/src/route-manager/openapi/openapi.types.ts
+++ b/src/route-manager/openapi/openapi.types.ts
@@ -40,6 +40,36 @@ export type InferPathsFromGroupForAnnotation<Version extends OASVersions, Group 
     [OperationId in keyof Group as Group[OperationId]['path']]?: GetPathSpecMeta<Version>
 }
 
-export type GetOperationSpecMeta<Version extends OASVersions> = Pick<Version extends '3.0' ? oas30.OperationObject : oas31.OperationObject,
+type OperationExtraMeta<OperationMeta extends string[]> = {
+    operation: OperationMeta
+}
+
+type InferExtraMeta<OperationMeta extends string[]> = {
+    [K in keyof OperationMeta[number]]: any
+}
+
+export type MetaManagerConfig<
+    SpecVersion extends OASVersions,
+    Tags extends TagItem<SpecVersion>[],
+    ExtraOperationMeta extends string[]
+> = {
+    version: SpecVersion,
+    tags?: Tags,
+    // Meta that doesn't exist natively in OpenAPI
+    customOperationMeta?: ExtraOperationMeta,
+    
+}
+
+type InferCustomMetaOperations<OperationMetaConfig extends MetaConfigBase<OASVersions>['customOperationMeta']> = OperationMetaConfig extends string[] ? {
+    [Item in OperationMetaConfig[number]]?: any
+} : {} 
+
+
+export type MetaConfigBase<SpecVersion extends OASVersions> = MetaManagerConfig<SpecVersion, TagItem<SpecVersion>[], string[]>
+
+export type GetOperationSpecMeta<Version extends OASVersions, MetaConfig extends MetaConfigBase<Version>['customOperationMeta']> = Pick<Version extends '3.0' ? oas30.OperationObject : oas31.OperationObject,
 'description' | 'summary' | 'deprecated' | 'security' | 'servers' | 'callbacks' | 'externalDocs'
->
+> & InferCustomMetaOperations<MetaConfig>
+
+export type TagItem<Version extends OASVersions> = Version extends '3.0' ? oas30.TagObject : oas31.TagObject
+


### PR DESCRIPTION
- Type-safe OpenAPI spec tags can now be specified
- Additional metadata can also be declared for operations which will be merged with the existing OpenAPI types