### PR TITLE
Release/0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thequinndev/docolate",
-  "version": "0.0.0-alpha.0",
+  "version": "0.1.0",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "package.json",
     "route-manager.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thequinndev/docolate.git"
+  },
   "author": "thequinndev",
   "license": "MIT",
   "dependencies": {

--- a/src/route-manager/openapi/index.ts
+++ b/src/route-manager/openapi/index.ts
@@ -1,3 +1,4 @@
 export * from './compiler'
 export * from './manager'
 export * from './openapi.types'
+export * from './meta-manager'

--- a/src/route-manager/openapi/manager/index.ts
+++ b/src/route-manager/openapi/manager/index.ts
@@ -1,11 +1,13 @@
 import { apiBuilder } from "../../build-endpoint";
 import { EndpointArrayByOperationIds, EndpointBase, InferRequestAccepts } from "../../endpoint";
-import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta } from '../openapi.types'
+import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta, MetaConfigBase, SafeTags } from '../openapi.types'
 
 export const OpenAPIManager = <
-    SpecVersion extends OASVersions
+    SpecVersion extends OASVersions,
+    MetaConfig extends MetaConfigBase<SpecVersion>,
 >(config: {
     version: SpecVersion,
+    metaManager?: MetaConfig,
     defaultMetadata?: {
         responses?: GetResponseSpecMetaDefault<SpecVersion>
     }
@@ -19,7 +21,11 @@ export const OpenAPIManager = <
         paths?: InferPathsFromGroupForAnnotation<SpecVersion, Operations>,
         operations?: {
             [OperationId in keyof Operations]?: {
-                operation?: GetOperationSpecMeta<SpecVersion>,
+                operation?: GetOperationSpecMeta<
+                    SpecVersion,
+                    MetaConfig extends MetaConfigBase<SpecVersion> ? MetaConfig['customOperationMeta'] : never,
+                    MetaConfig extends MetaConfigBase<SpecVersion> ? SafeTags<SpecVersion, MetaConfig['tags']> : never
+                >,
                 requestBody?: GetRequestBodySpecMeta<SpecVersion, InferRequestAccepts<Operations[OperationId]['accepts'], 'body'>>,
                 responses?: InferResponsesForExamples<SpecVersion, Operations[OperationId]>
             }

--- a/src/route-manager/openapi/meta-manager/index.test.ts
+++ b/src/route-manager/openapi/meta-manager/index.test.ts
@@ -1,0 +1,97 @@
+import { OpenAPIMetaManager } from ".";
+import { apiDocumentationEndpoints } from "../../../../examples/route-manager/endpoints"
+import { OpenAPIManager } from '../manager'
+
+describe("OpenAPIMetaManager", () => {
+
+    it("Will have no impact on OpenAPIManager if not provided", () => {
+
+        const apiManager = OpenAPIManager({
+            version: '3.0',
+        })
+        apiManager.addEndpointGroup(apiDocumentationEndpoints, {
+            'operations': {
+                'getApiDocumentation': {
+                    // The main test here is just that we don't get compiler errors when the extra keys are included
+                    'operation': {
+                        'description': 'Test',         
+                        'summary': 'Test',
+                    }
+                }
+            }
+        })
+
+        const operation = apiManager.build({failOnError: false}).spec.paths['/'].get
+
+        expect(operation['description']).toEqual('Test')
+        expect(operation['summary']).toEqual('Test')
+    })
+
+    it("Will make operations extensible in the OpenAPIManager", () => {
+        const metaManager = OpenAPIMetaManager({
+            version: '3.0',
+            customOperationMeta: [
+                'my-extra-key',
+                'any-key'
+            ]
+        })
+
+        const apiManager = OpenAPIManager({
+            version: '3.0',
+            metaManager: metaManager
+        })
+        apiManager.addEndpointGroup(apiDocumentationEndpoints, {
+            'operations': {
+                'getApiDocumentation': {
+                    // The main test here is just that we don't get compiler errors when the extra keys are included
+                    'operation': {
+                        'description': 'Test',
+                        // These should have no compiler errors
+                        'my-extra-key': 'MyKey1',
+                        'any-key': 'MyKey2'
+                    }
+                }
+            }
+        })
+
+        const operation = apiManager.build({failOnError: false}).spec.paths['/'].get
+
+        expect(operation['my-extra-key']).toEqual('MyKey1')
+        expect(operation['any-key']).toEqual('MyKey2')
+    })
+
+    it("Will make tags extensible in the OpenAPIManager", () => {
+        const metaManager = OpenAPIMetaManager({
+            version: '3.0',
+            tags: [
+                {
+                    name: 'MyTag',
+                    description: 'My Tag'
+                },
+                {
+                    name: 'MyOtherTag',
+                }
+            ]
+        })
+
+        const apiManager = OpenAPIManager({
+            version: '3.0',
+            metaManager: metaManager
+        })
+        apiManager.addEndpointGroup(apiDocumentationEndpoints, {
+            'operations': {
+                'getApiDocumentation': {
+                    // The main test here is just that we don't get compiler errors when the extra keys are included
+                    'operation': {
+                        'description': 'Test',
+                        'tags': ['MyTag', 'MyOtherTag'],
+                    }
+                }
+            }
+        })
+
+        const operation = apiManager.build({failOnError: false}).spec.paths['/'].get
+
+        expect(operation['tags']).toEqual(['MyTag', 'MyOtherTag'])
+    })
+});

--- a/src/route-manager/openapi/meta-manager/index.ts
+++ b/src/route-manager/openapi/meta-manager/index.ts
@@ -1,0 +1,11 @@
+import { MetaManagerConfig, OASVersions, TagItem } from "../openapi.types"
+
+export const OpenAPIMetaManager = <
+    SpecVersion extends OASVersions,
+    TagName extends string,
+    Tag extends TagItem<SpecVersion,TagName>,
+    ExtraOperationMeta extends string,
+>(config: MetaManagerConfig<
+    SpecVersion, Tag[], ExtraOperationMeta[]>) => {
+    return config
+}


### PR DESCRIPTION
- Introduction of OpenAPIMetaManager.
- This helper function allows you to declare top level tags and other metadata. You can then also derive from these while building your spec files.
