### PR TITLE
Patch/0.1.1

### DIFF
--- a/examples/route-manager/openapi/compiler/index.ts
+++ b/examples/route-manager/openapi/compiler/index.ts
@@ -1,6 +1,7 @@
 import { OpenAPISpecCompiler } from '@thequinndev/route-manager/openapi/compiler'
 import { writeFileSync } from 'fs';
 import { ApiDocumentExample, UserDocumentExample } from '../manager';
+import { metaManagerExample } from '../meta-manager'
 
 const compiler = OpenAPISpecCompiler({
     version: '3.0',
@@ -12,6 +13,7 @@ const compiler = OpenAPISpecCompiler({
             version: '1.0.0'
         }
     },
+    metaManager: metaManagerExample,
     openApiManagers: [
         ApiDocumentExample,
         UserDocumentExample

--- a/examples/route-manager/openapi/manager/index.ts
+++ b/examples/route-manager/openapi/manager/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIManager } from '@thequinndev/route-manager/openapi/manager'
 import { apiDocumentationEndpoints, userEndpoints } from '../../endpoints'
+import { metaManagerExample } from '../meta-manager';
 
 
 const missingDocs = OpenAPIManager({
@@ -10,6 +11,7 @@ missingDocs.addEndpointGroup(apiDocumentationEndpoints)
 
 const apiDocumentationDocument = OpenAPIManager({
     version: '3.0',
+    metaManager: metaManagerExample,
     // Only these fields are required, the rest are optional
     // paths and components are omitted because they are built for you
     defaultMetadata: {
@@ -37,7 +39,12 @@ apiDocumentationDocument.addEndpointGroup(apiDocumentationEndpoints, {
     operations: {
         'getApiDocumentation': {
             operation: {
-                description: 'The API Documentation'
+                description: 'The API Documentation',
+                tags: [
+                    'docolate',
+                    'example',
+                    'route-manager'
+                ]
             },
             responses: {
                 200: {

--- a/examples/route-manager/openapi/meta-manager/index.ts
+++ b/examples/route-manager/openapi/meta-manager/index.ts
@@ -1,0 +1,16 @@
+import { OpenAPIMetaManager } from '@thequinndev/route-manager/openapi/meta-manager'
+
+export const metaManagerExample = OpenAPIMetaManager({
+    version: '3.0',
+    tags: [
+        {
+            name: 'example'
+        },
+        {
+            name: 'docolate'
+        },
+        {
+            name: 'route-manager'
+        }
+    ]
+})

--- a/examples/route-manager/openapi/openapi.json
+++ b/examples/route-manager/openapi/openapi.json
@@ -82,7 +82,7 @@
       }
     },
     "parameters": {
-      "UserId": {
+      "PathUserId": {
         "in": "path",
         "name": "userId",
         "required": true,
@@ -90,7 +90,7 @@
           "type": "number"
         }
       },
-      "UserName": {
+      "QueryUserName": {
         "in": "query",
         "name": "name",
         "required": false,
@@ -106,6 +106,11 @@
       "summary": "Base Endpoint",
       "get": {
         "description": "The API Documentation",
+        "tags": [
+          "docolate",
+          "example",
+          "route-manager"
+        ],
         "operationId": "getApiDocumentation",
         "responses": {
           "200": {
@@ -168,7 +173,7 @@
         "operationId": "getUserById",
         "parameters": [
           {
-            "$ref": "#/components/parameters/UserId"
+            "$ref": "#/components/parameters/PathUserId"
           }
         ],
         "responses": {
@@ -316,7 +321,7 @@
         "operationId": "searchUsers",
         "parameters": [
           {
-            "$ref": "#/components/parameters/UserName"
+            "$ref": "#/components/parameters/QueryUserName"
           },
           {
             "in": "query",
@@ -456,5 +461,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "example"
+    },
+    {
+      "name": "docolate"
+    },
+    {
+      "name": "route-manager"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thequinndev/docolate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/route-manager/openapi/compiler/index.test.ts
+++ b/src/route-manager/openapi/compiler/index.test.ts
@@ -1,6 +1,7 @@
 import {OpenAPISpecCompiler} from '.'
 
 import { ApiDocumentExample, UserDocumentExample } from "../../../../examples/route-manager/openapi/manager"
+import { metaManagerExample } from "../../../../examples/route-manager/openapi/meta-manager"
 
 describe("OpenAPISpecCompiler", () => {
     it('Will compile all examples', () => {
@@ -13,6 +14,7 @@ describe("OpenAPISpecCompiler", () => {
                     version: '1.0.0'
                 }
             },
+            metaManager: metaManagerExample,
             openApiManagers: [
                 ApiDocumentExample,
                 UserDocumentExample
@@ -478,6 +480,17 @@ describe("OpenAPISpecCompiler", () => {
                 "summary": "User By ID Endpoints",
               },
             },
+            "tags": [
+              {
+                "name": "example",
+              },
+              {
+                "name": "docolate",
+              },
+              {
+                "name": "route-manager",
+              },
+            ],
           })
     })
 })

--- a/src/route-manager/openapi/compiler/index.ts
+++ b/src/route-manager/openapi/compiler/index.ts
@@ -1,7 +1,7 @@
 //specFile: SpecBodyVersion,
 
 import { oas31 } from "openapi3-ts";
-import { OASVersions, InferSpecBodyFromVersion } from "../openapi.types";
+import { OASVersions, InferSpecBodyFromVersion, MetaConfigBase } from "../openapi.types";
 import { Error } from '../../build-endpoint'
 
 interface OpenApiManager {
@@ -20,7 +20,8 @@ interface OpenApiManager {
 export const OpenAPISpecCompiler = <SpecVersion extends OASVersions>(config: {
   version: SpecVersion;
   specFile: InferSpecBodyFromVersion<SpecVersion>,
-  openApiManagers: OpenApiManager[];
+  openApiManagers: OpenApiManager[],
+  metaManager?: MetaConfigBase<SpecVersion>
 }) => {
     const build = (buildConfig?: {
         failOnError?: boolean,
@@ -69,6 +70,15 @@ export const OpenAPISpecCompiler = <SpecVersion extends OASVersions>(config: {
             specFile.paths = {
                 ...specFile.paths,
                 ...subBuild.spec.paths
+            }
+        }
+
+        if (config.metaManager) {
+            if (Array.isArray(config.metaManager.tags)) {
+                specFile.tags = [
+                    ...config.metaManager.tags,
+                    ...(specFile.tags ? specFile.tags : [])
+                ]
             }
         }
 


### PR DESCRIPTION
Missing from release 0.1.0. The tags declared in the meta manager should also be merged into the OpenAPI spec if you provide them meta manager to the spec compiler.