### PR TITLE
Release/0.2.0

### DIFF
--- a/examples/route-manager/openapi/manager/index.ts
+++ b/examples/route-manager/openapi/manager/index.ts
@@ -126,6 +126,14 @@ apiUserDocument.addEndpointGroup(userEndpoints, {
                         }
                     }
                 },
+            },
+            parameters: {
+                path: {
+                    'userId': {
+                        description: 'Test',
+                        example: 0,
+                    }
+                }
             }
         },
         'searchUsers': {
@@ -137,6 +145,16 @@ apiUserDocument.addEndpointGroup(userEndpoints, {
                 200: {
                     description: 'Successfully retrieved a list of users'
                 },
+            },
+            parameters: {
+                'query': {
+                    'description': {
+                        description: 'Example'
+                    },
+                    name: {
+                        description: 'Example'
+                    }
+                }
             }
         },
         'updateUser': {

--- a/examples/route-manager/openapi/openapi.json
+++ b/examples/route-manager/openapi/openapi.json
@@ -86,6 +86,8 @@
         "in": "path",
         "name": "userId",
         "required": true,
+        "description": "Test",
+        "example": 0,
         "schema": {
           "type": "number"
         }
@@ -94,6 +96,7 @@
         "in": "query",
         "name": "name",
         "required": false,
+        "description": "Example",
         "schema": {
           "type": "string"
         }
@@ -327,6 +330,7 @@
             "in": "query",
             "name": "description",
             "required": false,
+            "description": "Example",
             "schema": {
               "type": "string"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thequinndev/docolate",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/route-manager/build-endpoint/index.test.ts
+++ b/src/route-manager/build-endpoint/index.test.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod'
+import { apiBuilder } from '.'
+import { EndpointBase } from '../endpoint'
+
+describe("apiBuilder", () => {
+    describe('error cases', () => {
+        it('Will have errors if the endpoint path is missing parameters', () => {
+            const endpoint = {
+                method: 'get',
+                operationId: 'testOperation',
+                path: '/my-path/{param1}',
+                accepts: {
+                    path: z.object({
+                        param1: z.string(),
+                        param2: z.string() // This is missing from the path
+                    })
+                },
+                returns: {}
+            } as EndpointBase
+    
+            const builder = apiBuilder({failOnError: false, defaultMetadata: {}})
+            builder.buildParams(endpoint, 'path', [])
+
+            expect(builder.getErrors()).toEqual([
+                {
+                    "message": "Path /my-path/{param1} is missing parameter param2.",
+                    "method": "get",
+                    "operationId": "testOperation",
+                    "path": "/my-path/{param1}",
+                    "severity": "error",
+                  },
+            ])
+        })
+
+        it('Will throw an if the endpoint path is missing parameters - failOnError = true', () => {
+            const endpoint = {
+                method: 'get',
+                operationId: 'testOperation',
+                path: '/my-path/{param1}',
+                accepts: {
+                    path: z.object({
+                        param1: z.string(),
+                        param2: z.string() // This is missing from the path
+                    })
+                },
+                returns: {}
+            } as EndpointBase
+    
+
+
+            try {
+                const builder = apiBuilder({failOnError: true, defaultMetadata: {}})
+                builder.buildParams(endpoint, 'path', [])
+            } catch (error) {
+                expect(error).toEqual(new Error(JSON.stringify(
+                    {
+                        "message": "Path /my-path/{param1} is missing parameter param2.",
+                        "operationId": "testOperation",
+                        "path": "/my-path/{param1}",
+                        "method": "get",
+                        "severity": "error",
+                    }, null, 2)
+                ))
+            }
+
+        })
+
+        it('Will have errors if the parameters are not all declarted', () => {
+            const endpoint = {
+                method: 'get',
+                operationId: 'testOperation',
+                path: '/my-path/{param1}/{param2}',// param2 is missing from the accepts.path
+                accepts: {
+                    path: z.object({
+                        param1: z.string(),
+                    })
+                },
+                returns: {}
+            } as EndpointBase
+    
+            const builder = apiBuilder({failOnError: false, defaultMetadata: {}})
+            builder.buildParams(endpoint, 'path', [])
+
+            expect(builder.getErrors()).toEqual([
+                {
+                    "message": "Path parameter param2 is not declared, but exists in path /my-path/{param1}/{param2}.",
+                    "method": "get",
+                    "operationId": "testOperation",
+                    "path": "/my-path/{param1}/{param2}",
+                    "severity": "error",
+                  },
+            ])
+        })
+
+        it('Will throw an if the endpoint path is missing parameters - failOnError = true', () => {
+            const endpoint = {
+                method: 'get',
+                operationId: 'testOperation',
+                path: '/my-path/{param1}/{param2}',// param2 is missing from the accepts.path
+                accepts: {
+                    path: z.object({
+                        param1: z.string(),
+                    })
+                },
+                returns: {}
+            } as EndpointBase
+    
+
+
+            try {
+                const builder = apiBuilder({failOnError: true, defaultMetadata: {}})
+                builder.buildParams(endpoint, 'path', [])
+            } catch (error) {
+                expect(error).toEqual(new Error(JSON.stringify(
+                    {
+                        "message": "Path parameter param2 is not declared, but exists in path /my-path/{param1}/{param2}.",
+                        "operationId": "testOperation",
+                        "path": "/my-path/{param1}/{param2}",
+                        "method": "get",
+                        "severity": "error",
+                    }, null, 2)
+                ))
+            }
+
+        })
+
+    })
+})

--- a/src/route-manager/component-factory/index.ts
+++ b/src/route-manager/component-factory/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { RouteManagerErrors } from "../errors";
+import { schemaIs } from "../utility";
 
 export const ComponentFactory = <
 SchemaItems extends string,
@@ -11,7 +12,7 @@ Parameters extends ParameterItems[]
     parameters?: Parameters
 }) => {
     const makeSchema = <T extends z.ZodType<any>, Id extends Schemas[number]>(schema: T, id: Id) => {
-        if (schema instanceof z.ZodArray) {
+        if (schemaIs.array(schema)) {
             throw new Error(RouteManagerErrors.NoArrayRefs)
         }
         schema = schema.describe(id)
@@ -19,10 +20,10 @@ Parameters extends ParameterItems[]
     }
 
     const makeParameterItem = <T extends z.ZodType<any>, Id extends Parameters[number]>(parameter: T, id: Id) => {
-        if (parameter instanceof z.ZodArray) {
+        if (schemaIs.array(parameter)) {
             throw new Error(RouteManagerErrors.NoArrayParameter)
         }
-        if (parameter instanceof z.ZodObject) {
+        if (schemaIs.object(parameter)) {
             throw new Error(RouteManagerErrors.NoObjectParameter)
         }
         parameter = parameter.describe(id)

--- a/src/route-manager/errors/index.ts
+++ b/src/route-manager/errors/index.ts
@@ -11,4 +11,6 @@ export const RouteManagerErrors = {
     ].join('\n'),
     NoArrayParameter: "You cannot make parameters from arrays",
     NoObjectParameter: "You cannot make parameters from objects",
+    PathMissingParameter: (path: string, param: string) => `Path ${path} is missing parameter ${param}.`,
+    ParameterInPathNotDeclared: (path: string, param: string) => `Path parameter ${param} is not declared, but exists in path ${path}.`,
 }

--- a/src/route-manager/openapi/compiler/index.test.ts
+++ b/src/route-manager/openapi/compiler/index.test.ts
@@ -180,6 +180,11 @@ describe("OpenAPISpecCompiler", () => {
                       "description": "Internal server error",
                     },
                   },
+                  "tags": [
+                    "docolate",
+                    "example",
+                    "route-manager",
+                  ],
                 },
                 "summary": "Base Endpoint",
               },

--- a/src/route-manager/openapi/compiler/index.test.ts
+++ b/src/route-manager/openapi/compiler/index.test.ts
@@ -25,6 +25,8 @@ describe("OpenAPISpecCompiler", () => {
             "components": {
               "parameters": {
                 "PathUserId": {
+                  "description": "Test",
+                  "example": 0,
                   "in": "path",
                   "name": "userId",
                   "required": true,
@@ -33,6 +35,7 @@ describe("OpenAPISpecCompiler", () => {
                   },
                 },
                 "QueryUserName": {
+                  "description": "Example",
                   "in": "query",
                   "name": "name",
                   "required": false,
@@ -199,6 +202,7 @@ describe("OpenAPISpecCompiler", () => {
                       "$ref": "#/components/parameters/QueryUserName",
                     },
                     {
+                      "description": "Example",
                       "in": "query",
                       "name": "description",
                       "required": false,

--- a/src/route-manager/openapi/manager/index.test.ts
+++ b/src/route-manager/openapi/manager/index.test.ts
@@ -106,6 +106,11 @@ describe("OpenAPIManager", () => {
                                     "description": "Internal server error",
                                 },
                             },
+                            "tags": [
+                                "docolate",
+                                "example",
+                                "route-manager",
+                            ],
                         },
                         "summary": "Base Endpoint"
                     },

--- a/src/route-manager/openapi/manager/index.test.ts
+++ b/src/route-manager/openapi/manager/index.test.ts
@@ -126,6 +126,8 @@ describe("OpenAPIManager", () => {
         expect(document.spec.components).toEqual({
             "parameters": {
                 "PathUserId": {
+                    "description": "Test",
+                    "example": 0,
                     "in": "path",
                     "name": "userId",
                     "required": true,
@@ -134,6 +136,7 @@ describe("OpenAPIManager", () => {
                     },
                 },
                 "QueryUserName": {
+                    "description": "Example",
                     "in": "query",
                     "name": "name",
                     "required": false,
@@ -206,6 +209,7 @@ describe("OpenAPIManager", () => {
                         "$ref": "#/components/parameters/QueryUserName"
                     },
                     {
+                        "description": "Example",
                         "in": "query",
                         "name": "description",
                         "required": false,

--- a/src/route-manager/openapi/manager/index.ts
+++ b/src/route-manager/openapi/manager/index.ts
@@ -1,6 +1,6 @@
 import { apiBuilder } from "../../build-endpoint";
 import { EndpointArrayByOperationIds, EndpointBase, InferRequestAccepts } from "../../endpoint";
-import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta, MetaConfigBase, SafeTags } from '../openapi.types'
+import { OASVersions, GetResponseSpecMetaDefault, GetRequestBodySpecMeta, InferResponsesForExamples, InferPathsFromGroupForAnnotation, GetOperationSpecMeta, MetaConfigBase, SafeTags, InferPathParamsForExamples, InferQueryParamsForExamples } from '../openapi.types'
 
 export const OpenAPIManager = <
     SpecVersion extends OASVersions,
@@ -27,7 +27,11 @@ export const OpenAPIManager = <
                     MetaConfig extends MetaConfigBase<SpecVersion> ? SafeTags<SpecVersion, MetaConfig['tags']> : never
                 >,
                 requestBody?: GetRequestBodySpecMeta<SpecVersion, InferRequestAccepts<Operations[OperationId]['accepts'], 'body'>>,
-                responses?: InferResponsesForExamples<SpecVersion, Operations[OperationId]>
+                responses?: InferResponsesForExamples<SpecVersion, Operations[OperationId]>,
+                parameters?: {
+                    path?: InferPathParamsForExamples<Operations[OperationId]>,
+                    query?: InferQueryParamsForExamples<Operations[OperationId]>
+                }
             }
         }
 

--- a/src/route-manager/openapi/openapi.types.ts
+++ b/src/route-manager/openapi/openapi.types.ts
@@ -19,7 +19,7 @@ export type GetResponseSpecMetaDefault<Version extends OASVersions> = {
 }
 
 type InferObjectForExamples<T extends object> = {
-    [Key in keyof T]: {
+    [Key in keyof T]?: {
         description?: string
     } & ValidExamples<T[Key]>
 }

--- a/src/route-manager/openapi/openapi.types.ts
+++ b/src/route-manager/openapi/openapi.types.ts
@@ -18,6 +18,25 @@ export type GetResponseSpecMetaDefault<Version extends OASVersions> = {
     [Status in ValidStatusCodes]?: Omit<Version extends '3.0' ? oas30.ResponseObject : oas31.ResponseObject, 'content'>
 }
 
+type InferObjectForExamples<T extends object> = {
+    [Key in keyof T]: {
+        description?: string
+    } & ValidExamples<T[Key]>
+}
+
+export type InferPathParamsForExamples<
+Endpoint extends EndpointBase
+> = Endpoint['accepts'] extends {
+    path: z.ZodObject<any>
+} ? InferObjectForExamples<z.infer<Endpoint['accepts']['path']>> : never
+
+export type InferQueryParamsForExamples<
+Endpoint extends EndpointBase
+> = Endpoint['accepts'] extends {
+    query: z.ZodObject<any>
+} ? InferObjectForExamples<z.infer<Endpoint['accepts']['query']>> : never
+
+
 export type InferResponsesForExamples<
 Version extends OASVersions,
 Endpoint extends EndpointBase

--- a/src/route-manager/path-param-get/index.test.ts
+++ b/src/route-manager/path-param-get/index.test.ts
@@ -1,0 +1,21 @@
+import { getParamsFromPath } from '.'
+
+describe("getParamsFromPath", () => {
+
+    it('Will extract params like {param}', () => {
+        const result = getParamsFromPath('/my-path/{param1}/{param2}')
+        expect(result).toEqual({
+            param1: false,
+            param2: false
+        })
+    })
+
+    it('Will extract params like :param', () => {
+        const result = getParamsFromPath('/my-path/:param1/:param2')
+        expect(result).toEqual({
+            param1: false,
+            param2: false
+        })
+    })
+
+})

--- a/src/route-manager/path-param-get/index.ts
+++ b/src/route-manager/path-param-get/index.ts
@@ -1,0 +1,24 @@
+export const getParamsFromPath = (path: string): Record<string, false> => {
+
+    // First remove the leading slash
+    if (path.startsWith('/')) {
+        path = path.slice(1);
+    }
+
+    // Default to false as they will be set to true if found
+    const result: Record<string, false> = path.split('/').reduce((acc, item) => {
+        if ((item.includes('{') && item.includes('}'))) {
+            const key = item.replace('{', '').replace('}', '')
+            acc[key] = false
+        }
+        
+        if (item.includes(':')) {
+            const key = item.replace(':', '')
+            acc[key] = false
+        }
+
+        return acc;
+      }, {} as Record<string, false>);
+
+    return result
+}

--- a/src/route-manager/schema-process/index.ts
+++ b/src/route-manager/schema-process/index.ts
@@ -3,6 +3,7 @@ import zodToJsonSchema from "zod-to-json-schema";
 import { ValidRefFormat } from "../openapi/openapi.types";
 import { RouteManagerErrors } from "../errors";
 import { schemaPreProcess } from "./schema-pre-process";
+import { schemaIs } from "../utility";
 
 const refFormats = {
     schemas: '#/components/schemas' as ValidRefFormat,
@@ -59,7 +60,7 @@ export const SchemaProcessor = () => {
         for (const key in shape) {
             const valueSchema = shape[key];
 
-            if (valueSchema instanceof z.ZodObject) {
+            if (schemaIs.object(valueSchema)) {
                 const ref = getSchemaId(valueSchema)
                 const jsonSchema = processZodObject(valueSchema)
                 if (ref) {
@@ -89,7 +90,7 @@ export const SchemaProcessor = () => {
 
     const processSchema = (schema: z.ZodType<any>): any => {
 
-        if (schema instanceof z.ZodArray) {
+        if (schemaIs.array(schema)) {
 
             // Array components add a complexity overhead and prevent the underlying objects from being modular
             if (getSchemaId(schema)) {
@@ -98,8 +99,8 @@ export const SchemaProcessor = () => {
 
             const arrayJsonSchema = convertAndStrip(schema)
 
-            const internalSchema = schema.element
-            if (internalSchema instanceof z.ZodObject) {
+            const internalSchema = (schema as z.ZodArray<any>).element
+            if (schemaIs.object(internalSchema)) {
                 const ref = getSchemaId(internalSchema)
                 if (ref) {
                     const result = processZodObject(
@@ -121,7 +122,7 @@ export const SchemaProcessor = () => {
             return arrayJsonSchema
         }
 
-        if (schema instanceof z.ZodObject) {
+        if (schemaIs.object(schema)) {
             const ref = getSchemaId(schema)
             const result = processZodObject(
                 schema as z.ZodObject<any>

--- a/src/route-manager/utility/index.ts
+++ b/src/route-manager/utility/index.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const schemaIs = {
+    array: (schema: z.ZodType<any>) => {
+        return (schema as any)?._def?.typeName === 'ZodArray'
+    },
+    object: (schema: z.ZodType<any>) => {
+        return (schema as any)?._def?.typeName === 'ZodObject'
+    } 
+}


### PR DESCRIPTION
- Fixes for incorrect zod type checking. It was using instanceof instead of using the raw typeName inside the schema. This caused issues after transpiling.
- Includes the ability to annotate query and path parameters
- Fix for nested arrays inside objects which weren't be properly introspected to build their json schema.
- Error checking for missing parameters, both in the path and the parameter object.