### PR TITLE
refactor: schema parser

### DIFF
--- a/src/route-manager/build-endpoint/index.test.ts
+++ b/src/route-manager/build-endpoint/index.test.ts
@@ -18,7 +18,7 @@ describe("apiBuilder", () => {
                 returns: {}
             } as EndpointBase
     
-            const builder = apiBuilder({failOnError: false, defaultMetadata: {}})
+            const builder = apiBuilder({ version: '3.0', failOnError: false, defaultMetadata: {}})
             builder.buildParams(endpoint, 'path', [])
 
             expect(builder.getErrors()).toEqual([
@@ -49,7 +49,7 @@ describe("apiBuilder", () => {
 
 
             try {
-                const builder = apiBuilder({failOnError: true, defaultMetadata: {}})
+                const builder = apiBuilder({ version: '3.0', failOnError: true, defaultMetadata: {}})
                 builder.buildParams(endpoint, 'path', [])
             } catch (error) {
                 expect(error).toEqual(new Error(JSON.stringify(
@@ -78,7 +78,7 @@ describe("apiBuilder", () => {
                 returns: {}
             } as EndpointBase
     
-            const builder = apiBuilder({failOnError: false, defaultMetadata: {}})
+            const builder = apiBuilder({ version: '3.0', failOnError: false, defaultMetadata: {}})
             builder.buildParams(endpoint, 'path', [])
 
             expect(builder.getErrors()).toEqual([
@@ -108,7 +108,7 @@ describe("apiBuilder", () => {
 
 
             try {
-                const builder = apiBuilder({failOnError: true, defaultMetadata: {}})
+                const builder = apiBuilder({ version: '3.0', failOnError: true, defaultMetadata: {}})
                 builder.buildParams(endpoint, 'path', [])
             } catch (error) {
                 expect(error).toEqual(new Error(JSON.stringify(

--- a/src/route-manager/errors/index.ts
+++ b/src/route-manager/errors/index.ts
@@ -13,4 +13,8 @@ export const RouteManagerErrors = {
     NoObjectParameter: "You cannot make parameters from objects",
     PathMissingParameter: (path: string, param: string) => `Path ${path} is missing parameter ${param}.`,
     ParameterInPathNotDeclared: (path: string, param: string) => `Path parameter ${param} is not declared, but exists in path ${path}.`,
+    UnionTypeWarning: [
+        'The RouteManager module will most likely offer minimal support for schemas resulting in oneOf or anyOf.',
+        `See: https://github.com/thequinndev/docolate/wiki/Docolate-%E2%80%90-OpenAPIManager-%E2%80%90-A-note-on-union-objects-and-properties`
+    ].join('\n')
 }

--- a/src/route-manager/openapi/manager/index.ts
+++ b/src/route-manager/openapi/manager/index.ts
@@ -72,6 +72,7 @@ export const OpenAPIManager = <
         failOnError: boolean
     }) => {
         const builder = apiBuilder({
+            version: config.version,
             failOnError: buildConfig.failOnError,
             defaultMetadata: config.defaultMetadata ?? {}
         })

--- a/src/route-manager/schema-process/convert-and-strip/index.test.ts
+++ b/src/route-manager/schema-process/convert-and-strip/index.test.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { convertAndStrip } from "./index"
+
+describe("convertAndStrip", () => {
+  describe("with Primitives", () => {
+    it("Will remove useless json schema", () => {
+      const result = convertAndStrip(z.string().describe('RemoveMe'), '3.0')
+      expect(result).toEqual({
+        type: 'string'
+      })
+    })
+  });
+
+  describe("with Primitives derived from objects", () => {
+    it("Will remove useless json schema", () => {
+      const parent = z.object({
+        name: z.string()
+      })
+      const result = convertAndStrip(parent.shape.name.describe('RemoveMe'), '3.0')
+      expect(result).toEqual({
+        type: 'string'
+      })
+    })
+  });
+
+  describe("with Primitives derived from partial objects", () => {
+    it("Will remove useless json schema", () => {
+      const parent = z.object({
+        name: z.string()
+      }).partial()
+      const result = convertAndStrip(parent.shape.name.describe('RemoveMe'), '3.0')
+      expect(result).toEqual({
+        type: 'string'
+      })
+    })
+  });
+});

--- a/src/route-manager/schema-process/convert-and-strip/index.ts
+++ b/src/route-manager/schema-process/convert-and-strip/index.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import zodToJsonSchema from "zod-to-json-schema";
+import { schemaPreProcess } from "../schema-pre-process";
+import { OASVersions } from "../../openapi";
+import { schema30 } from "../schema30";
+
+export const convertAndStrip = (schema: z.ZodType<any>, version: OASVersions) => {
+    let jsonSchema = zodToJsonSchema(schema) as any;
+    jsonSchema = schemaPreProcess(jsonSchema, version)
+    delete jsonSchema["$ref"];
+    delete jsonSchema["$schema"];
+    delete jsonSchema["additionalProperties"];
+    delete jsonSchema["description"]
+
+    return jsonSchema;
+};

--- a/src/route-manager/schema-process/index.test.ts
+++ b/src/route-manager/schema-process/index.test.ts
@@ -5,14 +5,14 @@ import { RouteManagerErrors } from "../errors";
 describe("getSchemaId", () => {
   describe("with ID", () => {
     it("will return an ID if it exists (object)", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const testSchema = z.object({}).describe("Mock");
       const id = schemaProcessor.getSchemaId(testSchema);
       expect(id).toEqual("Mock");
     });
 
     it("will return an ID if it exists (property)", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const testSchema = z.string().describe("Mock");
       const id = schemaProcessor.getSchemaId(testSchema);
       expect(id).toEqual("Mock");
@@ -21,7 +21,7 @@ describe("getSchemaId", () => {
 
   describe("without ID", () => {
     it("will return null if it does not exist (object)", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const testSchema = z.object({});
       const id = schemaProcessor.getSchemaId(testSchema);
       expect(id).toEqual(null);
@@ -29,7 +29,7 @@ describe("getSchemaId", () => {
 
     it("will return null if it does not exist (property)", () => {
       const testSchema = z.string();
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const id = schemaProcessor.getSchemaId(testSchema);
       expect(id).toEqual(null);
     });
@@ -39,7 +39,7 @@ describe("getSchemaId", () => {
 describe("processSchema", () => {
   describe("with Object", () => {
     it("Will return a compiled json schema including refs", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const layer3 = z
         .object({
           key3: z.string(),
@@ -101,7 +101,7 @@ describe("processSchema", () => {
       });
     });
     it("Will return a compiled json schema including refs", () => {
-        const schemaProcessor = SchemaProcessor();
+        const schemaProcessor = SchemaProcessor('3.0');
 
         const layer2 = z
           .object({
@@ -137,7 +137,7 @@ describe("processSchema", () => {
           });
     });
     it("Will return a compiled json schema including refs - and handle no ref at the top level", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const layer3 = z
         .object({
           key3: z.string(),
@@ -197,7 +197,7 @@ describe("processSchema", () => {
 
   describe("with Object With Nested Arrays", () => {
     it("Will return a compiled json schema including refs", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const layer3 = z
         .object({
           key3: z.string(),
@@ -260,7 +260,7 @@ describe("processSchema", () => {
       });
     });
     it("Will return a compiled json schema including refs", () => {
-        const schemaProcessor = SchemaProcessor();
+        const schemaProcessor = SchemaProcessor('3.0');
 
         const layer2 = z
           .object({
@@ -296,7 +296,7 @@ describe("processSchema", () => {
           });
     });
     it("Will return a compiled json schema including refs - and handle no ref at the top level", () => {
-      const schemaProcessor = SchemaProcessor();
+      const schemaProcessor = SchemaProcessor('3.0');
       const layer3 = z
         .object({
           key3: z.string(),
@@ -358,7 +358,7 @@ describe("processSchema", () => {
     it("Will throw an error if you try to make an $ref array", () => {
         const invalidArray = z.object({name: z.string()}).array().describe('Anything')
         try {
-            const schemaProcessor = SchemaProcessor()
+            const schemaProcessor = SchemaProcessor('3.0')
             schemaProcessor.processSchema(invalidArray)
         } catch(error) {
             expect(error).toEqual(new Error(RouteManagerErrors.NoArrayRefs))
@@ -368,7 +368,7 @@ describe("processSchema", () => {
 
     it("Will return a primitive array as a normal schema", () => {
         const primitiveArray = z.string().array()
-        const schemaProcessor = SchemaProcessor()
+        const schemaProcessor = SchemaProcessor('3.0')
         expect(schemaProcessor.processSchema(primitiveArray)).toEqual({
             "items": {
                 "type": "string",
@@ -379,52 +379,15 @@ describe("processSchema", () => {
   });
 });
 
-describe("convertAndStrip", () => {
-    describe("with Primitives", () => {
-      it("Will remove useless json schema", () => {
-            const schemaProcessor = SchemaProcessor()
-            const result = schemaProcessor.convertAndStrip(z.string().describe('RemoveMe'))
-            expect(result).toEqual({
-                type: 'string'
-            })
-      })
-    });
 
-    describe("with Primitives derived from objects", () => {
-        it("Will remove useless json schema", () => {
-              const schemaProcessor = SchemaProcessor()
-              const parent = z.object({
-                name: z.string()
-              })
-              const result = schemaProcessor.convertAndStrip(parent.shape.name.describe('RemoveMe'))
-              expect(result).toEqual({
-                  type: 'string'
-              })
-        })
-      });
-
-      describe("with Primitives derived from partial objects", () => {
-        it("Will remove useless json schema", () => {
-              const schemaProcessor = SchemaProcessor()
-              const parent = z.object({
-                name: z.string()
-              }).partial()
-              const result = schemaProcessor.convertAndStrip(parent.shape.name.describe('RemoveMe'))
-              expect(result).toEqual({
-                  type: 'string'
-              })
-        })
-      });
+describe("getComponents", () => {
+  describe("with No previous action", () => {
+    it("Will return an empty object", () => {
+          const schemaProcessor = SchemaProcessor('3.0')
+          expect(schemaProcessor.getComponents()).toEqual({
+              components: {}
+          })
+    })
   });
 
-  describe("getComponents", () => {
-    describe("with No previous action", () => {
-      it("Will return an empty object", () => {
-            const schemaProcessor = SchemaProcessor()
-            expect(schemaProcessor.getComponents()).toEqual({
-                components: {}
-            })
-      })
-    });
-
-  });
+});

--- a/src/route-manager/schema-process/schema-pre-process/index.test.ts
+++ b/src/route-manager/schema-process/schema-pre-process/index.test.ts
@@ -1,0 +1,39 @@
+import zodToJsonSchema from 'zod-to-json-schema';
+import { schemaPreProcess } from '.'
+import { z } from 'zod';
+
+describe("schemaPreProcess", () => {
+    describe("with Primitives - 3.0", () => {
+      it("Will account for nullish string", () => {
+        const schema = zodToJsonSchema(z.string().nullish())
+        const result = schemaPreProcess(schema, '3.0')
+        expect(result).toEqual({
+            type: 'string',
+            nullable: true
+        })
+      })
+
+      it("Will account for nullish number", () => {
+        const schema = zodToJsonSchema(z.number().nullish())
+        const result = schemaPreProcess(schema, '3.0')
+        expect(result).toEqual({
+            type: 'number',
+            nullable: true
+        })
+      })
+
+      it("Will account for union", () => {
+        const schema = zodToJsonSchema(z.string().or(z.number()))
+        const result = schemaPreProcess(schema, '3.0')
+        expect(result.type).toEqual({
+            oneOf: [{
+                type: 'string',
+            },{
+                type: 'number',
+            }
+        ]
+        })
+      })
+
+    });
+});

--- a/src/route-manager/schema-process/schema-pre-process/index.ts
+++ b/src/route-manager/schema-process/schema-pre-process/index.ts
@@ -1,3 +1,6 @@
+import { OASVersions } from "../../openapi"
+import { schema30 } from "../schema30"
+
 const removeUselessAnyOf = (schema: any) => {
     if (Array.isArray(schema.anyOf)) {
         schema.anyOf = schema.anyOf.filter((item: any) => {
@@ -15,9 +18,13 @@ const removeUselessAnyOf = (schema: any) => {
     return schema
 }
 
-export const schemaPreProcess = (schema: any) => {
+export const schemaPreProcess = (schema: any, version: OASVersions) => {
     if (schema.anyOf) {
         schema = removeUselessAnyOf(schema)
+    }
+
+    if (version === '3.0') {
+        schema = schema30(schema)
     }
 
     return schema

--- a/src/route-manager/schema-process/schema30/index.ts
+++ b/src/route-manager/schema-process/schema30/index.ts
@@ -1,0 +1,24 @@
+export const schema30 = (schema: any) => {
+    
+    if (Array.isArray(schema.type)) {
+        // First determine if it contains null, in OAS3.0, you cannot have null as a type it must be nullable: true
+        if (schema.type.includes('null')) {
+            schema.type = schema.type.filter(item => item !== 'null')
+            schema.nullable = true
+        }
+
+        if (schema.type.length > 1) {
+            schema.type = {
+                oneOf: schema.type.map(item => {
+                    return {type: item}
+                })
+            }
+        }
+
+        if (schema.type.length === 1) {
+            schema.type = schema.type[0]
+        }
+    }
+
+    return schema
+}


### PR DESCRIPTION
- split out the schemaParser functions so v30 and v31 could be more easily tested.
- include a warning to the error log to mention the minimal intended support for union types